### PR TITLE
Fix long word subject overflow

### DIFF
--- a/app/internal_packages/message-list/styles/message-list.less
+++ b/app/internal_packages/message-list/styles/message-list.less
@@ -219,6 +219,7 @@ body.platform-win32 {
     font-size: @font-size-large;
     color: @text-color;
     margin-right: @spacing-standard;
+    overflow-wrap: anywhere;
   }
   .message-icons-wrap {
     flex-shrink: 0;


### PR DESCRIPTION
Fixes this:
<img width="1371" alt="image" src="https://github.com/probablykasper/Mailspring/assets/11315492/aed7cc10-48d7-499c-a1c4-4e749cadd5bc">


New:

<img width="1372" alt="image" src="https://github.com/probablykasper/Mailspring/assets/11315492/8b216ec6-c454-45d4-a4b9-7bac39a30bc3">